### PR TITLE
Allow building as static library and to skip installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.12)
 
 project(PalImageViewer VERSION 0.2 LANGUAGES CXX)
 
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(PIV_STANDALONE ON)
+    set(BUILD_SHARED_LIBS ON)
+endif()
+
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
@@ -49,42 +54,47 @@ endif()
 ####### Targets #######
 
 add_subdirectory(src)
-add_subdirectory(example)
+
+if (PIV_STANDALONE)
+    add_subdirectory(example)
+endif()
 
 
 ####### Package Installation #######
 
-install(
-    EXPORT PalImageViewerTargets
-    FILE PalImageViewerTargets.cmake
-    NAMESPACE Pal::
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalImageViewer"
-    COMPONENT PalImageViewerDevel
-)
+if (PIV_STANDALONE)
+    install(
+        EXPORT PalImageViewerTargets
+        FILE PalImageViewerTargets.cmake
+        NAMESPACE Pal::
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalImageViewer"
+        COMPONENT PalImageViewerDevel
+     )
 
-# Setup Qt dependency check
-set(PIV_QT_DEPENDENCY "${PIV_QT} COMPONENTS Core Gui Widgets")
-configure_package_config_file(
-    "${PROJECT_SOURCE_DIR}/PalImageViewerConfig.cmake.in"
-    "${PROJECT_BINARY_DIR}/PalImageViewerConfig.cmake"
-    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalImageViewer"
-)
+    # Setup Qt dependency check
+    set(PIV_QT_DEPENDENCY "${PIV_QT} COMPONENTS Core Gui Widgets")
+    configure_package_config_file(
+        "${PROJECT_SOURCE_DIR}/PalImageViewerConfig.cmake.in"
+        "${PROJECT_BINARY_DIR}/PalImageViewerConfig.cmake"
+        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalImageViewer"
+    )
 
-write_basic_package_version_file(
-    "${PROJECT_BINARY_DIR}/PalImageViewerConfigVersion.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion
-)
+    write_basic_package_version_file(
+        "${PROJECT_BINARY_DIR}/PalImageViewerConfigVersion.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY ExactVersion
+    )
 
-install(
-    FILES "${PROJECT_BINARY_DIR}/PalImageViewerConfig.cmake"
-          "${PROJECT_BINARY_DIR}/PalImageViewerConfigVersion.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalImageViewer"
-    COMPONENT PalImageViewerDevel
-)
+    install(
+        FILES "${PROJECT_BINARY_DIR}/PalImageViewerConfig.cmake"
+              "${PROJECT_BINARY_DIR}/PalImageViewerConfigVersion.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalImageViewer"
+        COMPONENT PalImageViewerDevel
+    )
 
-export(
-    TARGETS ImageViewer
-    NAMESPACE Pal::
-    FILE PalImageViewerTargets.cmake
-)
+    export(
+        TARGETS ImageViewer
+        NAMESPACE Pal::
+        FILE PalImageViewerTargets.cmake
+    )
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####### Library #######
 
-add_library(ImageViewer SHARED
+add_library(ImageViewer
     ${PROJECT_BINARY_DIR}/include/pal/image-viewer-export.h
     ${PROJECT_SOURCE_DIR}/include/pal/image-viewer.h
     image-viewer.cpp
@@ -43,24 +43,26 @@ target_link_libraries(ImageViewer
 
 ####### Library installation #######
 
-install(
-    TARGETS ImageViewer
-    EXPORT PalImageViewerTargets
-    RUNTIME
-        DESTINATION "${CMAKE_INSTALL_BINDIR}"
-        COMPONENT PalImageViewerRuntime
-    LIBRARY
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        COMPONENT PalImageViewerRuntime
-        NAMELINK_COMPONENT PalImageViewerDevel
-    ARCHIVE
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        COMPONENT PalImageViewerDevel
-)
+if (PIV_STANDALONE)
+    install(
+        TARGETS ImageViewer
+        EXPORT PalImageViewerTargets
+        RUNTIME
+            DESTINATION "${CMAKE_INSTALL_BINDIR}"
+            COMPONENT PalImageViewerRuntime
+        LIBRARY
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            COMPONENT PalImageViewerRuntime
+            NAMELINK_COMPONENT PalImageViewerDevel
+        ARCHIVE
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            COMPONENT PalImageViewerDevel
+    )
 
-install(
-    FILES ${PROJECT_BINARY_DIR}/include/pal/image-viewer-export.h
-          ${PROJECT_SOURCE_DIR}/include/pal/image-viewer.h
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/pal"
-    COMPONENT PalImageViewerDevel
-)
+    install(
+        FILES ${PROJECT_BINARY_DIR}/include/pal/image-viewer-export.h
+              ${PROJECT_SOURCE_DIR}/include/pal/image-viewer.h
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/pal"
+        COMPONENT PalImageViewerDevel
+    )
+endif()

--- a/src/image-viewer.cpp
+++ b/src/image-viewer.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <mutex>
 #include <QApplication>
 #include <QEnterEvent>
 #include <QGraphicsScene>
@@ -11,6 +12,11 @@
 #include <QWheelEvent>
 #include "pal/image-viewer.h"
 
+static void init_image_viewer_resource() {
+    // This must be done outside of any namespace
+    Q_INIT_RESOURCE(image_viewer);
+}
+
 namespace pal {
 
 // Graphics View with better mouse events handling
@@ -21,6 +27,9 @@ public:
         : QGraphicsView()
         , m_viewer(viewer)
     {
+        static std::once_flag inititialized;
+        std::call_once(inititialized, init_image_viewer_resource);
+
         // no antialiasing or filtering, we want to see the exact image content
         setRenderHint(QPainter::Antialiasing, false);
         setDragMode(QGraphicsView::ScrollHandDrag);


### PR DESCRIPTION
This adds two CMake options to faciliate the use of this library as
submodule:
- PIV_SHARED: set to "OFF" to build as either STATIC or SHARED library,
  depending on BUILD_SHARED_LIBS
- PIV_INSTALL: set to "OFF" to skip generation of installation rules

Both options default to "ON"