### PR TITLE
Improve trackpad zoom behavior

### DIFF
--- a/src/image-viewer.cpp
+++ b/src/image-viewer.cpp
@@ -48,9 +48,10 @@ protected:
         const auto d = event->angleDelta();
 
         if (event->modifiers() == Qt::NoModifier) {
-            if (d.x() > 0 || d.y() > 0)
+            auto dm = abs(d.x()) > abs(d.y()) ? d.x() : d.y();
+            if (dm > 0)
                 m_viewer->zoomIn(3);
-            else if (d.x() < 0 || d.y() < 0)
+            else if (dm < 0)
                 m_viewer->zoomOut(3);
             event->accept();
         }


### PR DESCRIPTION
Use absolute maximum value of d.x() and d.y() to decide zoom direction.